### PR TITLE
Refactoring step 1: clean up naming & fix issues

### DIFF
--- a/HERO Arcade Drive Example1/Program.cs
+++ b/HERO Arcade Drive Example1/Program.cs
@@ -2,13 +2,20 @@
 using CTRE.Phoenix.Controller;
 using CTRE.Phoenix.MotorControl;
 using CTRE.Phoenix.MotorControl.CAN;
-using Microsoft.SPOT;
-using System;
-using System.Text;
 using System.Threading;
 
 namespace TShirtCannonStarter
 {
+    public enum DeviceIDs : int
+    {
+        DRIVE_LEFT_LEAD = 11,
+        DRIVE_LEFT_FOLLOW = 12,
+        DRIVE_RIGHT_LEAD = 13,
+        DRIVE_RIGHT_FOLLOW = 14,
+        ACTUATOR_MOTOR = 15,
+    }
+
+    
     public enum GamepadButtons : uint
     {
         BUTTON_1 = 1,
@@ -21,13 +28,22 @@ namespace TShirtCannonStarter
         RIGHT_TRIGGER = 8
     }
 
+    public enum GamepadAxes : uint
+    {
+        DRIVE_X = 0,
+        DRIVE_Y = 1,
+        TWIST = 2,
+    }
+
     public class Program
     {
-        static VictorSPX leftLead = new VictorSPX(11);
-        static VictorSPX leftFollow = new VictorSPX(12);
-        static VictorSPX rightLead = new VictorSPX(13);
-        static VictorSPX rightFollow = new VictorSPX(14);
-        static VictorSPX actuator = new VictorSPX(15);
+        static double ACTUATOR_DRIVE_POWER = 0.5;
+
+        static VictorSPX leftLead = new VictorSPX((int)DeviceIDs.DRIVE_LEFT_LEAD);
+        static VictorSPX leftFollow = new VictorSPX((int)DeviceIDs.DRIVE_LEFT_FOLLOW);
+        static VictorSPX rightLead = new VictorSPX((int)DeviceIDs.DRIVE_RIGHT_LEAD);
+        static VictorSPX rightFollow = new VictorSPX((int)DeviceIDs.DRIVE_RIGHT_FOLLOW);
+        static VictorSPX actuator = new VictorSPX((int)DeviceIDs.ACTUATOR_MOTOR);
 
         static CTRE.Phoenix.Controller.GameController _gamepad = null;
 
@@ -75,9 +91,9 @@ namespace TShirtCannonStarter
         static void Drive()
         {
             /* Get gamepad axis inputs */
-            float x = _gamepad.GetAxis(0);
-            float y = -1 * _gamepad.GetAxis(1);
-            float twist = _gamepad.GetAxis(2);
+            float x = _gamepad.GetAxis((uint)GamepadAxes.DRIVE_X);
+            float y = -1 * _gamepad.GetAxis((uint)GamepadAxes.DRIVE_Y);
+            float twist = _gamepad.GetAxis((uint)GamepadAxes.TWIST);
 
             /* Deadband gamepad axis inputs */
             float deadbandWidth = (float)0.10;
@@ -104,11 +120,11 @@ namespace TShirtCannonStarter
 
             if (actuatorUp)
             {
-                actuator.Set(ControlMode.PercentOutput, 0.5);
+                actuator.Set(ControlMode.PercentOutput, ACTUATOR_DRIVE_POWER);
             }
             else if (actuatorDown)
             {
-                actuator.Set(ControlMode.PercentOutput, -0.5);
+                actuator.Set(ControlMode.PercentOutput, -ACTUATOR_DRIVE_POWER);
             }
             else
             {

--- a/TShirtCannon-2023.sln
+++ b/TShirtCannon-2023.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.33801.447
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TShirtCannon-Starter", "HERO Arcade Drive Example1\TShirtCannon-Starter.csproj", "{421BBD0E-5D76-48FF-962D-54C77D856E06}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TShirtCannon-2023", "TShirtCannon\TShirtCannon-2023.csproj", "{421BBD0E-5D76-48FF-962D-54C77D856E06}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/TShirtCannon/Program.cs
+++ b/TShirtCannon/Program.cs
@@ -4,7 +4,7 @@ using CTRE.Phoenix.MotorControl;
 using CTRE.Phoenix.MotorControl.CAN;
 using System.Threading;
 
-namespace TShirtCannonStarter
+namespace TShirtCannon2023
 {
     public enum DeviceIDs : int
     {
@@ -15,7 +15,6 @@ namespace TShirtCannonStarter
         ACTUATOR_MOTOR = 15,
     }
 
-    
     public enum GamepadButtons : uint
     {
         BUTTON_1 = 1,
@@ -92,7 +91,7 @@ namespace TShirtCannonStarter
         {
             /* Get gamepad axis inputs */
             float x = _gamepad.GetAxis((uint)GamepadAxes.DRIVE_X);
-            float y = -1 * _gamepad.GetAxis((uint)GamepadAxes.DRIVE_Y);
+            float y = _gamepad.GetAxis((uint)GamepadAxes.DRIVE_Y);
             float twist = _gamepad.GetAxis((uint)GamepadAxes.TWIST);
 
             /* Deadband gamepad axis inputs */
@@ -102,8 +101,8 @@ namespace TShirtCannonStarter
             Deadband(ref twist, deadbandWidth);
 
             /* Compute throttle for each side of the robot */
-            float leftThrot = y + twist;
-            float rightThrot = y - twist;
+            float leftThrot = y - twist;
+            float rightThrot = y + twist;
 
             /* Set the motor percent output on each motor
              * based on the computed throttle. */
@@ -144,13 +143,11 @@ namespace TShirtCannonStarter
                 {
                     /* For testing only. This should trigger the spike for
                      * high pressure shot from high barrel. */
-                    // actuator.Set(ControlMode.PercentOutput, 1.0);
                 }
                 else
                 {
                     /* For testing only. This should trigger the spike for
                      * low pressure shot from high barrel. */
-                    // actuator.Set(ControlMode.PercentOutput, 0.3);
                 }
             }
             else
@@ -158,7 +155,6 @@ namespace TShirtCannonStarter
                 /* For testing only. This should ensure we don't
                  * trigger the high barrel for some number of cycles
                  * after a shot. */
-                // actuator.Set(ControlMode.PercentOutput, 0.0);
             }
         }
 
@@ -174,13 +170,11 @@ namespace TShirtCannonStarter
                 {
                     /* For testing only. This should trigger the spike for
                      * high pressure shot from low barrel. */
-                    // actuator.Set(ControlMode.PercentOutput, -1.0);
                 }
                 else
                 {
                     /* For testing only. This should trigger the spike for
                      * low pressure shot from low barrel. */
-                    // actuator.Set(ControlMode.PercentOutput, -0.3);
                 }
             }
             else
@@ -188,7 +182,6 @@ namespace TShirtCannonStarter
                 /* For testing only. This should ensure we don't
                  * trigger the low barrel for some number of cycles
                  * after a shot. */
-                // actuator.Set(ControlMode.PercentOutput, 0.0);
             }
         }
     }

--- a/TShirtCannon/Properties/AssemblyInfo.cs
+++ b/TShirtCannon/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("HERO Arcade Drive Example1")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyTitle("TShirtCannon")]
+[assembly: AssemblyDescription("FRC Team 2992 T-Shirt Cannon 2023")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("HERO Arcade Drive Example1")]
+[assembly: AssemblyCompany("Mandeville High School Robotics Team")]
+[assembly: AssemblyProduct("TShirtCannon")]
 [assembly: AssemblyCopyright("Copyright ©  2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/TShirtCannon/TShirtCannon-2023.csproj
+++ b/TShirtCannon/TShirtCannon-2023.csproj
@@ -4,9 +4,9 @@
     <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyName>TShirtCannon-Starter</AssemblyName>
+    <AssemblyName>TShirtCannon-2023</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RootNamespace>TShirtCannonStarter</RootNamespace>
+    <RootNamespace>TShirtCannon2023</RootNamespace>
     <ProjectTypeGuids>{b69e3092-b931-443c-abe7-7e7b65f2a37f};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProductVersion>9.0.21022</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>


### PR DESCRIPTION
This PR cleans up naming across the code base with the following steps:

- cleaning up references to example projects and such from HERO
- creating enum types for values we'll use for mapping gamepad buttons or device IDs, etc
- setting appropriate project details in the properties files
- fixing reversed drivetrain controls

Tested on the robot and it works as expected.