### PR TITLE
Remap buttons for shooting from barrels to simplify control

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ output from the spike) for states mapped to differing shot executions:
 | Signal 2 ON  |   MED AIR    |    HI AIR    |
 
 In code, this is controlled through two GPIO ports, one for each signal line
-to the spike relay. These are mapped to button inputs controlling whether the
-signal lines are triggered which tied to low pressure shots and high pressure
-shots respectively. Shots are executed by a third button mapped for a shot for
-each barrel, and shots are debounced to happen for a triggering happening for
-a duration of one robot cycle in a given interval of a few seconds.
+to the spike relay. These are mapped to button inputs indicating whether to
+shoot high, medium, or low air shots. Barrel selection is done by a separate
+button mapping, and the barrel selection must be held while the shot is
+triggered. Shots are debounced to happen for each barrel triggering happening
+for a duration of one robot cycle in a given interval of a few seconds.
 
 ### Supporting code files
 

--- a/TShirtCannon-2023.sln
+++ b/TShirtCannon-2023.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 16.0.33801.447
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TShirtCannon-2023", "TShirtCannon\TShirtCannon-2023.csproj", "{421BBD0E-5D76-48FF-962D-54C77D856E06}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A6A5DE75-87DB-4A00-8C3B-EC0D7F770B16}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/TShirtCannon/Barrel.cs
+++ b/TShirtCannon/Barrel.cs
@@ -9,8 +9,9 @@ namespace TShirtCannon2023.Subsystems
         private SafeOutputPort spikeLow;
 
         private GamepadButtonMappings shootTrigger;
-        private GamepadButtonMappings highPressure;
-        private GamepadButtonMappings lowPressure;
+        private GamepadButtonMappings highShot;
+        private GamepadButtonMappings mediumShot;
+        private GamepadButtonMappings lowShot;
 
         private uint debounceCounter;
 
@@ -18,13 +19,15 @@ namespace TShirtCannon2023.Subsystems
             Microsoft.SPOT.Hardware.Cpu.Pin spikeHighPin,
             Microsoft.SPOT.Hardware.Cpu.Pin spikeLowPin,
             GamepadButtonMappings shootTrigger,
-            GamepadButtonMappings highPressure,
-            GamepadButtonMappings lowPressure
+            GamepadButtonMappings highShot,
+            GamepadButtonMappings mediumShot,
+            GamepadButtonMappings lowShot
         )
         {
             this.shootTrigger = shootTrigger;
-            this.highPressure = highPressure;
-            this.lowPressure = lowPressure;
+            this.highShot = highShot;
+            this.mediumShot = mediumShot;
+            this.lowShot = lowShot;
 
             spikeHigh = new SafeOutputPort(spikeHighPin, false);
             spikeLow = new SafeOutputPort(spikeLowPin, false);
@@ -37,12 +40,16 @@ namespace TShirtCannon2023.Subsystems
             if (debounceShot())
             {
                 bool shootBarrel = gamepad.GetButton((uint)shootTrigger);
-                bool pressureLow = gamepad.GetButton((uint)lowPressure);
-                bool pressureHigh = gamepad.GetButton((uint)highPressure);
+                bool triggerSpikeLow = (
+                    gamepad.GetButton((uint)lowShot) || gamepad.GetButton((uint)highShot)
+                );
+                bool triggerSpikeHigh = (
+                    gamepad.GetButton((uint)mediumShot) || gamepad.GetButton((uint)highShot)
+                );
 
                 if (shootBarrel)
                 {
-                    if (pressureHigh)
+                    if (triggerSpikeHigh)
                     {
                         spikeHigh.Write(true);
                     }
@@ -51,7 +58,7 @@ namespace TShirtCannon2023.Subsystems
                         spikeHigh.Write(false);
                     }
 
-                    if (pressureLow)
+                    if (triggerSpikeLow)
                     {
                         spikeLow.Write(true);
                     }

--- a/TShirtCannon/ButtonMappings.cs
+++ b/TShirtCannon/ButtonMappings.cs
@@ -15,11 +15,10 @@ namespace TShirtCannon2023
     public enum GamepadButtonMappings : uint
     {
         LOW_BARREL_SHOOT = GamepadButtons.RIGHT_TRIGGER,
-        LOW_BARREL_LOW_PRESSURE = GamepadButtons.BUTTON_2,
-        LOW_BARREL_HIGH_PRESSURE = GamepadButtons.BUTTON_1,
         HIGH_BARREL_SHOOT = GamepadButtons.RIGHT_BUMPER,
-        HIGH_BARREL_LOW_PRESSURE = GamepadButtons.BUTTON_3,
-        HIGH_BARREL_HIGH_PRESSURE = GamepadButtons.BUTTON_4,
+        LOW_SHOT = GamepadButtons.BUTTON_2,
+        MEDIUM_SHOT = GamepadButtons.BUTTON_3,
+        HIGH_SHOT = GamepadButtons.BUTTON_4,
         ACTUATOR_UP = GamepadButtons.LEFT_BUMPER,
         ACTUATOR_DOWN = GamepadButtons.LEFT_TRIGGER,
     }

--- a/TShirtCannon/RobotMain.cs
+++ b/TShirtCannon/RobotMain.cs
@@ -24,15 +24,17 @@ namespace TShirtCannon2023
             DigitalIOPins.HIGH_BARREL_HIGH_PRESSURE,
             DigitalIOPins.HIGH_BARREL_LOW_PRESSURE,
             GamepadButtonMappings.HIGH_BARREL_SHOOT,
-            GamepadButtonMappings.HIGH_BARREL_HIGH_PRESSURE,
-            GamepadButtonMappings.HIGH_BARREL_LOW_PRESSURE);
+            GamepadButtonMappings.HIGH_SHOT,
+            GamepadButtonMappings.MEDIUM_SHOT,
+            GamepadButtonMappings.LOW_SHOT);
 
         static Barrel lowBarrel = new Barrel(
             DigitalIOPins.LOW_BARREL_HIGH_PRESSURE,
             DigitalIOPins.LOW_BARREL_LOW_PRESSURE,
             GamepadButtonMappings.LOW_BARREL_SHOOT,
-            GamepadButtonMappings.LOW_BARREL_HIGH_PRESSURE,
-            GamepadButtonMappings.LOW_BARREL_LOW_PRESSURE);
+            GamepadButtonMappings.HIGH_SHOT,
+            GamepadButtonMappings.MEDIUM_SHOT,
+            GamepadButtonMappings.LOW_SHOT);
 
         static CTRE.Phoenix.Controller.GameController _gamepad = null;
 


### PR DESCRIPTION
 This remaps controls for shooting from barrels as follows:

```
  LB  LT   |   RT  RB      (LT below LB, RT below RB)
 ____ _    |    _ ____
|____|_|___|___|_|____|
|       -     -    4  |
|  +     -       1   3|
|    __O_______O__ 2  |
|   /             \   |
|__/               \__|

```

| Barrel | Air | Barrel Selector | Shot Trigger |
|--------|-----|-----------------|--------------|
| Upper  | Low | Right Bumper    | Button 2     |
| Upper  | Med | Right Bumper    | Button 3     |
| Upper  | Hi  | Right Bumper    | Button 4     |
| Lower  | Low | Right Trigger   | Button 2     |
| Lower  | Med | Right Trigger   | Button 3     |
| Lower  | Hi  | Right Trigger   | Button 4     |

Remaining items for this PR:

- [x] Test shooting upper barrel low air
- [x] Test shooting upper barrel medium air
- [x] Test shooting upper barrel high air
- [x] Test shooting lower barrel low air
- [x] Test shooting lower barrel medium air
- [x] Test shooting lower barrel high air