### PR TITLE
Add DISABLED/ENABLED modes for the robot (WIP: verify button mappings)

### DIFF
--- a/TShirtCannon/Actuator.cs
+++ b/TShirtCannon/Actuator.cs
@@ -18,6 +18,11 @@ namespace TShirtCannon2023.Subsystems
             downButton = down;
         }
 
+        public void disable()
+        {
+            actuator.Set(ControlMode.PercentOutput, 0.0);
+        }
+
         public void executeCycle(GameController gamepad)
         {
             bool actuatorUp = gamepad.GetButton((uint)upButton);

--- a/TShirtCannon/Barrel.cs
+++ b/TShirtCannon/Barrel.cs
@@ -32,6 +32,12 @@ namespace TShirtCannon2023.Subsystems
             debounceCounter = 0;
         }
 
+        public void disable()
+        {
+            spikeHigh.Write(false);
+            spikeLow.Write(false);
+        }
+
         public void executeCycle(GameController gamepad)
         {
             if (debounceShot())

--- a/TShirtCannon/ButtonMappings.cs
+++ b/TShirtCannon/ButtonMappings.cs
@@ -9,7 +9,10 @@ namespace TShirtCannon2023
         LEFT_BUMPER = 5,
         RIGHT_BUMPER = 6,
         LEFT_TRIGGER = 7,
-        RIGHT_TRIGGER = 8
+        RIGHT_TRIGGER = 8,
+        SELECT_BUTTON = 9,
+        START_BUTTON = 10,
+        EXTRA_BUTTON = 11
     }
 
     public enum GamepadButtonMappings : uint
@@ -22,6 +25,8 @@ namespace TShirtCannon2023
         HIGH_BARREL_HIGH_PRESSURE = GamepadButtons.BUTTON_4,
         ACTUATOR_UP = GamepadButtons.LEFT_BUMPER,
         ACTUATOR_DOWN = GamepadButtons.LEFT_TRIGGER,
+        ENABLE_ROBOT = GamepadButtons.START_BUTTON,
+        DISABLE_ROBOT = GamepadButtons.SELECT_BUTTON
     }
 
     public enum GamepadAxes : uint

--- a/TShirtCannon/ControlConstants.cs
+++ b/TShirtCannon/ControlConstants.cs
@@ -1,5 +1,11 @@
 namespace TShirtCannon2023
 {
+    public enum RobotModes
+    {
+        DISABLED,
+        ENABLED
+    }
+
     public enum DeviceIDs : int
     {
         DRIVE_LEFT_LEAD = 11,

--- a/TShirtCannon/Drivetrain.cs
+++ b/TShirtCannon/Drivetrain.cs
@@ -49,6 +49,14 @@ namespace TShirtCannon2023.Subsystems
             rightFollow.Set(ControlMode.PercentOutput, -rightThrot);
         }
 
+        public void disable()
+        {
+            leftLead.Set(ControlMode.PercentOutput, 0.0);
+            leftFollow.Set(ControlMode.PercentOutput, 0.0);
+            rightLead.Set(ControlMode.PercentOutput, 0.0);
+            rightFollow.Set(ControlMode.PercentOutput, 0.0);
+        }
+
         /**
          * If value is within 10% of center, clear it.
          * @param value [out] floating point value to deadband.

--- a/TShirtCannon/RobotMain.cs
+++ b/TShirtCannon/RobotMain.cs
@@ -36,6 +36,8 @@ namespace TShirtCannon2023
 
         static CTRE.Phoenix.Controller.GameController _gamepad = null;
 
+        static RobotModes robotMode = RobotModes.DISABLED;
+
         public static void Main()
         {
             /* loop forever */
@@ -44,6 +46,8 @@ namespace TShirtCannon2023
                 if (null == _gamepad)
                     _gamepad = new GameController(UsbHostDevice.GetInstance());
 
+                /* enable the robot? */
+                robotMode = getRobotMode(_gamepad, robotMode);
                 /* drive robot using gamepad */
                 drivetrain.executeCycle(_gamepad);
                 /* control linear actuator for aim */
@@ -52,11 +56,41 @@ namespace TShirtCannon2023
                 highBarrel.executeCycle(_gamepad);
                 lowBarrel.executeCycle(_gamepad);
 
-                /* feed watchdog to keep all devices enabled */
-                CTRE.Phoenix.Watchdog.Feed();
+                if (robotMode == RobotModes.ENABLED)
+                {
+                    /* feed watchdog to keep all devices enabled */
+                    CTRE.Phoenix.Watchdog.Feed();
+                }
                 /* run this task every 20ms */
                 Thread.Sleep(20);
             }
+        }
+
+        static RobotModes getRobotMode(GameController gamepad, RobotModes currentMode)
+        {
+            if (gamepad == null)
+            {
+                return RobotModes.DISABLED;
+            }
+            if (gamepad.GetConnectionStatus() == UsbDeviceConnection.NotConnected)
+            {
+                return RobotModes.DISABLED;
+            }
+            
+            bool enableRobot = gamepad.GetButton(
+                (uint)GamepadButtonMappings.ENABLE_ROBOT);
+            bool disableRobot = gamepad.GetButton(
+                (uint)GamepadButtonMappings.DISABLE_ROBOT);
+
+            if (enableRobot && !disableRobot)
+            {
+                return RobotModes.ENABLED;
+            }
+            if (disableRobot)
+            {
+                return RobotModes.DISABLED;
+            }
+            return currentMode;
         }
     }
 }


### PR DESCRIPTION
This PR adds Disabled and Enabled modes to the robot.

It does this via a new enum `RobotModes` with values `ENABLED` and `DISABLED`, as well as new methods in each subsystem class `disable` that set all devices to a disabled/stopped state.

The main loop is rewritten to get the current robot mode, possibly changing it based on controller connectivity and mapped buttons for mode change (which need testing), and either execute the robot cycle on each subsystem or disable each subsystem accordingly.

A new boolean `feedDevices` is also added and set in the same static method that gets the current robot mode. This is used to gate whether the call to `CTRE.Phoenix.Watchdog.Feed()` is made on each cycle. A separate boolean is used for this so that we can ensure that for the first cycle after changing the robot mode to Disabled, we can still feed devices the disabled/stopped values, then not feed devices anymore following that.

Remaining items for this PR:

- [ ] Test disable via controller disconnect
- [ ] Test that all subsystems appropriately stop when disabled
- [ ] Validate new button mappings (or decide on new ones) and test them