### PR TITLE
Upgrade simple arcade drive to smooth inputs

### DIFF
--- a/TShirtCannon/ControlConstants.cs
+++ b/TShirtCannon/ControlConstants.cs
@@ -20,7 +20,7 @@ namespace TShirtCannon2023
     public class DrivetrainConstants
     {
         public static float DEADBAND_THRESHOLD = (float)0.10;
-        public static float STICK_GAIN_FACTOR = (float)0.30;
+        public static float STICK_GAIN_FACTOR = (float)0.90;
         public static float STICK_INV_DEADBAND = (float)0.0;
     }
 

--- a/TShirtCannon/ControlConstants.cs
+++ b/TShirtCannon/ControlConstants.cs
@@ -19,7 +19,9 @@ namespace TShirtCannon2023
 
     public class DrivetrainConstants
     {
-        public static float DEADBAND_WIDTH = (float)0.10;
+        public static float DEADBAND_THRESHOLD = (float)0.10;
+        public static float STICK_GAIN_FACTOR = (float)0.30;
+        public static float STICK_INV_DEADBAND = (float)0.0;
     }
 
     public class ShootingConstants

--- a/TShirtCannon/Drivetrain.cs
+++ b/TShirtCannon/Drivetrain.cs
@@ -79,8 +79,8 @@ namespace TShirtCannon2023.Subsystems
         private float[] computeThrottle(float forwardAxis, float twistAxis)
         {
             /* Square inputs to smooth low-speed drive */
-            float forward = forwardAxis * forwardAxis;
-            float twist = twistAxis * twistAxis;
+            float forward = forwardAxis * forwardAxis * (float)Math.Sign(forwardAxis);
+            float twist = twistAxis * twistAxis * (float)Math.Sign(twistAxis);
 
             /* Compute throttle for each side of the robot
              * via constant-curvature drive */

--- a/TShirtCannon/Drivetrain.cs
+++ b/TShirtCannon/Drivetrain.cs
@@ -35,8 +35,8 @@ namespace TShirtCannon2023.Subsystems
             float twist = gamepad.GetAxis((uint)twistAxis);
 
             /* Deadband gamepad axis inputs */
-            forward = deadband(forward, DrivetrainConstants.DEADBAND_WIDTH);
-            twist = deadband(twist, DrivetrainConstants.DEADBAND_WIDTH);
+            forward = deadband(forward, DrivetrainConstants.DEADBAND_THRESHOLD);
+            twist = deadband(twist, DrivetrainConstants.DEADBAND_THRESHOLD);
 
             /* Compute throttles */
             float[] throttles = computeThrottle(forward, twist);
@@ -52,35 +52,66 @@ namespace TShirtCannon2023.Subsystems
         }
 
         /**
-         * If value is within 10% of center, clear it.
+         * If value is within threshold of center, clear it.
          * @param value [out] floating point value to deadband.
          */
-        private float deadband(float value, float width)
+        private float deadband(float value, float threshold)
         {
-            if (value < -width)
+            // Force Limit from -1.0 to 1.0
+            value = (float)Math.Max(-1, Math.Min(1, value));
+
+            // Check If Value is Inside the Deadzone
+            if (value >= 0.0)
             {
-                /* outside of deadband */
-                return value;
-            }
-            else if (value > +width)
-            {
-                /* outside of deadband */
-                return value;
+                if (Math.Abs(value) >= threshold)
+                {
+                    return (value - threshold) / (1 - threshold);
+                }
+                else
+                {
+                    return (float)0.0;
+                }
             }
             else
             {
-                /* within the percent width so zero it */
-                return (float)0.0;
+                if (Math.Abs(value) >= threshold)
+                {
+                    return (value + threshold) / (1 - threshold);
+                }
+                else
+                {
+                    return (float)0.0;
+                }
             }
         }
 
-        /* Compute an array of smoothed (via squaring and constant curvature
-         * throttles for left and right drive motors */
+        /* Smooth an input value via mixing linear and cubic gain
+         * curves. See the following reference for more detail:
+         * https://www.chiefdelphi.com/t/paper-joystick-sensitivity-gain-adjustment/107280
+         */
+        private float smoothInput(float x)
+        {
+            float a = DrivetrainConstants.STICK_GAIN_FACTOR;
+            float b = DrivetrainConstants.STICK_INV_DEADBAND;
+
+            if (x > 0.0)
+            {
+                return (float)(b + (1.0 - b) * (a * x * x * x + (1.0 - a) * x));
+            }
+            if (x < 0.0)
+            {
+                return (float)(-b + (1.0 - b) * (a * x * x * x + (1.0 - a) * x));
+            }
+            return (float)0.0;
+        }
+
+        /* Compute an array of smoothed throttles for left 
+         * and right drive motors */
         private float[] computeThrottle(float forwardAxis, float twistAxis)
         {
-            /* Square inputs to smooth low-speed drive */
-            float forward = forwardAxis * forwardAxis * (float)Math.Sign(forwardAxis);
-            float twist = twistAxis * twistAxis * (float)Math.Sign(twistAxis);
+            /* Smooth inputs for better control at low-speed drive */
+            float forward = smoothInput(forwardAxis);
+            float twist = smoothInput(twistAxis);
 
             /* Compute throttle for each side of the robot
              * via constant-curvature drive */


### PR DESCRIPTION
This PR now implements better deadbanding and smoothing of stick inputs based on [deadbanding code in Mandevillorian's code base](https://github.com/FRCTeam2992/Robot2020/blob/88eea3b78aec59c7612dfa1cfedc65ec889dc61e/src/main/java/frc/lib/drive/mhJoystick.java#L51) and [the referenced ChiefDelphi thread](https://www.chiefdelphi.com/t/paper-joystick-sensitivity-gain-adjustment/107280/5).

Initial constants are set at:

- Deadband threshold = 0.1 (10%)
- Stick gain factor (mixing of linear and cubic modes) = ~~0.3~~ 0.9
- Stick inverse deadband factor = 0.0 (we can add some of this if needed later)

Remaining items for this PR:

- [ ] Test deadbanding and input smoothing by driving robot
- [ ] Tune constants as needed
