### PR TITLE
Modify drive turn code to facilitate turning the bot more easily

### DIFF
--- a/TShirtCannon/ControlConstants.cs
+++ b/TShirtCannon/ControlConstants.cs
@@ -22,6 +22,7 @@ namespace TShirtCannon2023
         public static float DEADBAND_THRESHOLD = (float)0.10;
         public static float STICK_GAIN_FACTOR = (float)0.90;
         public static float STICK_INV_DEADBAND = (float)0.0;
+        public static float TWIST_SCALING = (float)1.0;
     }
 
     public class ShootingConstants

--- a/TShirtCannon/Drivetrain.cs
+++ b/TShirtCannon/Drivetrain.cs
@@ -113,12 +113,8 @@ namespace TShirtCannon2023.Subsystems
             float forward = smoothInput(forwardAxis);
             float twist = smoothInput(twistAxis);
 
-            /* Compute throttle for each side of the robot
-             * via constant-curvature drive */
-            float posForward = (float)Math.Abs(forward);
-
-            float leftThrot = forward - posForward * twist;
-            float rightThrot = forward + posForward * twist;
+            float leftThrot = forward - DrivetrainConstants.TWIST_SCALING * twist;
+            float rightThrot = forward + DrivetrainConstants.TWIST_SCALING * twist;
 
             /* Scale by maxOutput to ensure no more than 100% power */
             float maxOutput = (float)Math.Max(


### PR DESCRIPTION
While testing #5, we noticed difficulty turning the robot, in particular, an inability to turn from stopped. This PR modifies turn code to enable turning the bot more easily.

Tested on the robot.