### PR TITLE
Add multi-cycle shot timing and use a constant for cycle duration

### DIFF
--- a/TShirtCannon/ControlConstants.cs
+++ b/TShirtCannon/ControlConstants.cs
@@ -1,5 +1,13 @@
 namespace TShirtCannon2023
 {
+    public enum BarrelShotTypes
+    {
+        NOT_SHOOTING,
+        LOW_AIR_VOLUME,
+        MED_AIR_VOLUME,
+        HIGH_AIR_VOLUME
+    }
+    
     public enum DeviceIDs : int
     {
         DRIVE_LEFT_LEAD = 11,
@@ -17,6 +25,11 @@ namespace TShirtCannon2023
         public static Microsoft.SPOT.Hardware.Cpu.Pin LOW_BARREL_HIGH_PRESSURE = CTRE.HERO.IO.Port6.Pin5;
     }
 
+    public class RobotConstants
+    {
+        public static int robotCycleTimeMs = 20;
+    }
+
     public class DrivetrainConstants
     {
         public static float DEADBAND_THRESHOLD = (float)0.10;
@@ -27,8 +40,10 @@ namespace TShirtCannon2023
 
     public class ShootingConstants
     {
-        // 3 seconds at 50 cycles (20ms each) per second
-        public static uint DEBOUNCE_WAIT_CYCLES = 3 * 50;
+        // 2 seconds at 50 cycles (20ms each) per second
+        public static int DEBOUNCE_WAIT_CYCLES = 2 * 50;
+        // Keep air open for this many cycles (20ms each)
+        public static uint SHOT_CYCLES = 5;
     }
 
     public class ActuatorConstants

--- a/TShirtCannon/ControlConstants.cs
+++ b/TShirtCannon/ControlConstants.cs
@@ -27,7 +27,8 @@ namespace TShirtCannon2023
 
     public class RobotConstants
     {
-        public static int robotCycleTimeMs = 20;
+        public static int robotCycleTimeMs = 10;
+        public static double codeExecutionTimeMs = 5.8;
     }
 
     public class DrivetrainConstants
@@ -40,10 +41,10 @@ namespace TShirtCannon2023
 
     public class ShootingConstants
     {
-        // 2 seconds at 50 cycles (20ms each) per second
-        public static int DEBOUNCE_WAIT_CYCLES = 2 * 50;
-        // Keep air open for this many cycles (20ms each)
-        public static uint SHOT_CYCLES = 5;
+        // n seconds at (robotCycleTimeMs each) per second
+        public static int DEBOUNCE_WAIT_CYCLES = (int)(2.0 * (1000.0/RobotConstants.robotCycleTimeMs));
+        // Keep air open for this many cycles (robotCycleTimeMs each)
+        public static uint SHOT_CYCLES = 3;
     }
 
     public class ActuatorConstants

--- a/TShirtCannon/RobotMain.cs
+++ b/TShirtCannon/RobotMain.cs
@@ -56,8 +56,10 @@ namespace TShirtCannon2023
 
                 /* feed watchdog to keep all devices enabled */
                 CTRE.Phoenix.Watchdog.Feed();
-                /* run this task every 20ms */
-                Thread.Sleep(RobotConstants.robotCycleTimeMs);
+                /* run this task every robotCycleTimeMs (offset by code execution time) */
+                Thread.Sleep(
+                    (int)(RobotConstants.robotCycleTimeMs - RobotConstants.codeExecutionTimeMs)
+                );
             }
         }
     }

--- a/TShirtCannon/RobotMain.cs
+++ b/TShirtCannon/RobotMain.cs
@@ -57,7 +57,7 @@ namespace TShirtCannon2023
                 /* feed watchdog to keep all devices enabled */
                 CTRE.Phoenix.Watchdog.Feed();
                 /* run this task every 20ms */
-                Thread.Sleep(20);
+                Thread.Sleep(RobotConstants.robotCycleTimeMs);
             }
         }
     }


### PR DESCRIPTION
This PR adds multi-cycle shot timing (currently set at 3 cycles), managing debounce counter separate from shot timer. This also creates a new enum for shot type and updates some new constants for managing shot timing and robot cycle duration. We also added a new constant from measured approximate compute time per cycle to offset sleep timing between cycles.

This has been tested on the robot and confirmed working.